### PR TITLE
Update to logical OR operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=5.4.0",
-		"illuminate/database": "5.0.*|5.1.*"
+		"illuminate/database": "5.0.*||5.1.*"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Unable to install on Laravel 5.1, this logical OR operator should resolve dependencies.

Was receiving:

```
composer require "ooxif/laravel-query-param"
Using version ^1.0 for ooxif/laravel-query-param                    
./composer.json has been updated
> php artisan clear-compiled
Loading composer repositories with package information                                                                                                                                                          Updating dependencies (including require-dev)         Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove laravel/framework v5.1.29
    - Conclusion: don't install laravel/framework v5.1.29
    - ooxif/laravel-query-param 1.0.0 requires illuminate/database 5.0.* -> satisfiable by laravel/framework[5.0.x-dev], illuminate/database[5.0.x-dev, v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.27, v5.0.28, v5.0.33, v5.0.4].
    - ooxif/laravel-query-param 1.0.1 requires illuminate/database 5.0.* -> satisfiable by laravel/framework[5.0.x-dev], illuminate/database[5.0.x-dev, v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.27, v5.0.28, v5.0.33, v5.0.4].
    - ooxif/laravel-query-param 1.0.2 requires illuminate/database 5.0.* -> satisfiable by laravel/framework[5.0.x-dev], illuminate/database[5.0.x-dev, v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.27, v5.0.28, v5.0.33, v5.0.4].
    - Can only install one of: laravel/framework[5.0.x-dev, v5.1.29].
    - don't install illuminate/database 5.0.x-dev|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.0|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.22|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.25|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.26|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.27|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.28|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.33|don't install laravel/framework v5.1.29
    - don't install illuminate/database v5.0.4|don't install laravel/framework v5.1.29
    - Installation request for laravel/framework == 5.1.29.0 -> satisfiable by laravel/framework[v5.1.29].
    - Installation request for ooxif/laravel-query-param ^1.0 -> satisfiable by ooxif/laravel-query-param[1.0.0, 1.0.1, 1.0.2].


Installation failed, reverting ./composer.json to its original content.
```

Further documented on [composer's website](https://getcomposer.org/doc/articles/versions.md#range).
